### PR TITLE
[1.21] More API improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ repositories {
     }
 }
 
+group = project.mod_group_id
+
 base {
     archivesName = "${archive_base_name}-${mod_version}+mc${minecraft_version}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,10 @@ base {
     archivesName = "${archive_base_name}-${mod_version}+mc${minecraft_version}"
 }
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(21)
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
+    withSourcesJar()
+}
 
 runs {
     // applies to all the run configs below

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,3 +12,5 @@ pluginManagement {
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
 }
+
+rootProject.name = 'modular-routers'

--- a/src/main/java/me/desht/modularrouters/api/event/AddModuleTargetEvent.java
+++ b/src/main/java/me/desht/modularrouters/api/event/AddModuleTargetEvent.java
@@ -1,0 +1,61 @@
+package me.desht.modularrouters.api.event;
+
+import me.desht.modularrouters.item.module.TargetedModule;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Event fired when a player attempts to add a new target to a module.
+ * <p>
+ * This event can be used to allow a module to target blocks it otherwise couldn't in conjunction with {@link ExecuteModuleEvent}.
+ */
+public final class AddModuleTargetEvent extends Event {
+    private final TargetedModule item;
+    private final UseOnContext context;
+    private boolean valid;
+
+    @ApiStatus.Internal
+    public AddModuleTargetEvent(TargetedModule item, UseOnContext context, boolean valid) {
+        this.item = item;
+        this.context = context;
+        this.valid = valid;
+    }
+
+    /**
+     * {@return the module type}
+     */
+    public TargetedModule getModuleType() {
+        return item;
+    }
+
+    /**
+     * {@return the module stack}
+     */
+    public ItemStack getModule() {
+        return context.getItemInHand();
+    }
+
+    /**
+     * {@return the context of the interaction}
+     */
+    public UseOnContext getContext() {
+        return context;
+    }
+
+    /**
+     * {@return whether the targeted block is valid and may be selected}
+     */
+    public boolean isValid() {
+        return valid;
+    }
+
+    /**
+     * Making the target {@code valid} allows the player to select the block and the router to process it.
+     * @see ExecuteModuleEvent
+     */
+    public void setValid(boolean valid) {
+        this.valid = valid;
+    }
+}

--- a/src/main/java/me/desht/modularrouters/api/event/RouterCompiledEvent.java
+++ b/src/main/java/me/desht/modularrouters/api/event/RouterCompiledEvent.java
@@ -27,7 +27,7 @@ public abstract sealed class RouterCompiledEvent extends Event {
     }
 
     /**
-     * Called when a router compiles its upgrades. This <strong>will</strong> be called on
+     * Called when a router (re)compiles its upgrades. This <strong>will</strong> be called on
      * the client-side too when the GUI is opened.
      */
     public final static class Upgrades extends RouterCompiledEvent {
@@ -38,7 +38,7 @@ public abstract sealed class RouterCompiledEvent extends Event {
     }
 
     /**
-     * Called when a router compiles its modules.
+     * Called when a router (re)compiles its modules.
      */
     public final static class Modules extends RouterCompiledEvent {
         public Modules(ModularRouterBlockEntity router) {

--- a/src/main/java/me/desht/modularrouters/api/event/RouterCompiledEvent.java
+++ b/src/main/java/me/desht/modularrouters/api/event/RouterCompiledEvent.java
@@ -1,0 +1,48 @@
+package me.desht.modularrouters.api.event;
+
+import me.desht.modularrouters.block.tile.ModularRouterBlockEntity;
+import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Called when a router is (re)compiled. Can be used to update state that's
+ * independent of an upgrade or module and must be refreshed even when the upgrade isn't present.
+ *
+ * @see Upgrades
+ * @see Modules
+ */
+public abstract sealed class RouterCompiledEvent extends Event {
+    private final ModularRouterBlockEntity router;
+
+    @ApiStatus.Internal
+    public RouterCompiledEvent(ModularRouterBlockEntity router) {
+        this.router = router;
+    }
+
+    /**
+     * {@return the router that is being compiled}
+     */
+    public ModularRouterBlockEntity getRouter() {
+        return router;
+    }
+
+    /**
+     * Called when a router compiles its upgrades. This <strong>will</strong> be called on
+     * the client-side too when the GUI is opened.
+     */
+    public final static class Upgrades extends RouterCompiledEvent {
+        @ApiStatus.Internal
+        public Upgrades(ModularRouterBlockEntity router) {
+            super(router);
+        }
+    }
+
+    /**
+     * Called when a router compiles its modules.
+     */
+    public final static class Modules extends RouterCompiledEvent {
+        public Modules(ModularRouterBlockEntity router) {
+            super(router);
+        }
+    }
+}

--- a/src/main/java/me/desht/modularrouters/block/tile/ModularRouterBlockEntity.java
+++ b/src/main/java/me/desht/modularrouters/block/tile/ModularRouterBlockEntity.java
@@ -3,6 +3,7 @@ package me.desht.modularrouters.block.tile;
 import com.google.common.collect.Sets;
 import com.mojang.authlib.GameProfile;
 import me.desht.modularrouters.ModularRouters;
+import me.desht.modularrouters.api.event.RouterCompiledEvent;
 import me.desht.modularrouters.block.CamouflageableBlock;
 import me.desht.modularrouters.block.ModularRouterBlock;
 import me.desht.modularrouters.config.ConfigHolder;
@@ -604,6 +605,7 @@ public class ModularRouterBlockEntity extends BlockEntity implements ICamouflage
                     if (cms.careAboutItemAttributes()) careAboutItemAttributes = true;
                 }
             }
+            NeoForge.EVENT_BUS.post(new RouterCompiledEvent.Modules(this));
         }
     }
 
@@ -638,6 +640,8 @@ public class ModularRouterBlockEntity extends BlockEntity implements ICamouflage
                 }
                 notifyWatchingPlayers();
             }
+
+            NeoForge.EVENT_BUS.post(new RouterCompiledEvent.Upgrades(this));
         }
     }
 
@@ -1075,7 +1079,7 @@ public class ModularRouterBlockEntity extends BlockEntity implements ICamouflage
                 if (inSlot.isEmpty() || slot == i) continue;
                 // can't have the same upgrade in more than one slot
                 // incompatible upgrades can't coexist
-                if (stack.getItem() == inSlot.getItem() || !((UpgradeItem) inSlot.getItem()).isCompatibleWith(item)) {
+                if (stack.getItem() == inSlot.getItem() || !((UpgradeItem) inSlot.getItem()).isCompatibleWith(item) || !item.isCompatibleWith((UpgradeItem) inSlot.getItem())) {
                     return false;
                 }
             }

--- a/src/main/java/me/desht/modularrouters/item/module/TargetedModule.java
+++ b/src/main/java/me/desht/modularrouters/item/module/TargetedModule.java
@@ -113,6 +113,7 @@ public abstract class TargetedModule extends ModuleItem {
                     .append(tgt.getTextComponent()).withStyle(ChatFormatting.YELLOW), true);
             world.playSound(null, pos, ModSounds.SUCCESS.get(), SoundSource.BLOCKS, ConfigHolder.common.sound.bleepVolume.get().floatValue(), 1.1f);
             setTargetList(stack, targets);
+            return InteractionResult.SUCCESS;
         }
 
         if (canSelectTarget(context)) {

--- a/src/main/java/me/desht/modularrouters/item/module/TargetedModule.java
+++ b/src/main/java/me/desht/modularrouters/item/module/TargetedModule.java
@@ -2,6 +2,7 @@ package me.desht.modularrouters.item.module;
 
 import com.google.common.collect.Sets;
 import me.desht.modularrouters.ModularRouters;
+import me.desht.modularrouters.api.event.AddModuleTargetEvent;
 import me.desht.modularrouters.block.tile.ModularRouterBlockEntity;
 import me.desht.modularrouters.client.util.ClientUtil;
 import me.desht.modularrouters.config.ConfigHolder;
@@ -32,6 +33,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 import java.util.Set;
@@ -51,23 +54,35 @@ public abstract class TargetedModule extends ModuleItem {
     @Override
     public InteractionResult useOn(UseOnContext ctx) {
         if (ctx.getPlayer() != null && ctx.getPlayer().isShiftKeyDown()) {
-            if (isValidTarget(ctx)) {
-                if (getMaxTargets() == 1) {
+            if (getMaxTargets() == 1) {
+                if (canSelectTarget(ctx)) {
                     handleSingleTarget(ctx.getItemInHand(), ctx.getPlayer(), ctx.getLevel(), ctx.getClickedPos(), ctx.getClickedFace());
-                } else {
-                    handleMultiTarget(ctx.getItemInHand(), ctx.getPlayer(), ctx.getLevel(), ctx.getClickedPos(), ctx.getClickedFace());
+                    return InteractionResult.SUCCESS;
                 }
-                return InteractionResult.SUCCESS;
             } else {
-                return super.useOn(ctx);
+                var res = handleMultiTarget(ctx.getItemInHand(), ctx, ctx.getPlayer(), ctx.getLevel(), ctx.getClickedPos(), ctx.getClickedFace());
+                if (res == InteractionResult.PASS) return res;
             }
+            return super.useOn(ctx);
         } else {
             return InteractionResult.PASS;
         }
     }
 
+    /**
+     * <strong>Override-only</strong> method that checks whether this module can have the block of the context selected.
+     * <p>Note: it is not guaranteed that the module will only have blocks that pass this test selected, see {@link AddModuleTargetEvent}.
+     */
+    @ApiStatus.OverrideOnly
     protected boolean isValidTarget(UseOnContext ctx) {
         return InventoryUtils.getInventory(ctx.getLevel(), ctx.getClickedPos(), ctx.getClickedFace()).isPresent();
+    }
+
+    /**
+     * Checks if the module can select the target of the {@code context}.
+     */
+    public boolean canSelectTarget(UseOnContext context) {
+        return NeoForge.EVENT_BUS.post(new AddModuleTargetEvent(this, context, isValidTarget(context))).isValid();
     }
 
     private void handleSingleTarget(ItemStack stack, Player player, Level world, BlockPos pos, Direction face) {
@@ -83,34 +98,43 @@ public abstract class TargetedModule extends ModuleItem {
         }
     }
 
-    private void handleMultiTarget(ItemStack stack, Player player, Level world, BlockPos pos, Direction face) {
-        if (!world.isClientSide) {
-            boolean removing = false;
-            String invName = BlockUtil.getBlockName(world, pos);
-            GlobalPos gPos = MiscUtil.makeGlobalPos(world, pos);
-            ModuleTarget tgt = new ModuleTarget(gPos, face, invName);
-            Set<ModuleTarget> targets = getTargets(stack, true);
-            if (targets.contains(tgt)) {
-                targets.remove(tgt);
-                removing = true;
-                player.displayClientMessage(Component.translatable("modularrouters.chatText.misc.targetRemoved", targets.size(), getMaxTargets())
-                        .append(tgt.getTextComponent()).withStyle(ChatFormatting.YELLOW), true);
-            } else if (targets.size() < getMaxTargets()) {
+    private InteractionResult handleMultiTarget(ItemStack stack, UseOnContext context, Player player, Level world, BlockPos pos, Direction face) {
+        Set<ModuleTarget> targets = getTargets(stack, !world.isClientSide);
+        String invName = BlockUtil.getBlockName(world, pos);
+        GlobalPos gPos = MiscUtil.makeGlobalPos(world, pos);
+        ModuleTarget tgt = new ModuleTarget(gPos, face, invName);
+
+        // Allow removing targets without checking if they're valid
+        if (targets.contains(tgt)) {
+            if (world.isClientSide) return InteractionResult.SUCCESS;
+            targets.remove(tgt);
+
+            player.displayClientMessage(Component.translatable("modularrouters.chatText.misc.targetRemoved", targets.size(), getMaxTargets())
+                    .append(tgt.getTextComponent()).withStyle(ChatFormatting.YELLOW), true);
+            world.playSound(null, pos, ModSounds.SUCCESS.get(), SoundSource.BLOCKS, ConfigHolder.common.sound.bleepVolume.get().floatValue(), 1.1f);
+            setTargetList(stack, targets);
+        }
+
+        if (canSelectTarget(context)) {
+            if (world.isClientSide) return InteractionResult.SUCCESS;
+            if (targets.size() < getMaxTargets()) {
                 targets.add(tgt);
                 player.displayClientMessage(Component.translatable("modularrouters.chatText.misc.targetAdded", targets.size(), getMaxTargets())
                         .append(tgt.getTextComponent()).withStyle(ChatFormatting.YELLOW), true);
+
+                world.playSound(null, pos, ModSounds.SUCCESS.get(), SoundSource.BLOCKS,
+                        ConfigHolder.common.sound.bleepVolume.get().floatValue(), 1.3f);
+                setTargetList(stack, targets);
             } else {
                 // too many targets already
                 player.displayClientMessage(Component.translatable("modularrouters.chatText.misc.tooManyTargets", getMaxTargets())
                         .withStyle(ChatFormatting.RED), true);
                 world.playSound(null, pos, ModSounds.ERROR.get(), SoundSource.BLOCKS, 1.0f, 1.3f);
-                return;
             }
 
-            world.playSound(null, pos, ModSounds.SUCCESS.get(), SoundSource.BLOCKS,
-                    ConfigHolder.common.sound.bleepVolume.get().floatValue(), removing ? 1.1f : 1.3f);
-            setTargetList(stack, targets);
+            return InteractionResult.SUCCESS;
         }
+        return InteractionResult.PASS;
     }
 
 


### PR DESCRIPTION
This PR adds a few more improvements to the API to facilitate [MIR](https://legacy.curseforge.com/minecraft/mc-mods/modern-industrial-routers)'s use cases and more expansion in general:
- make routers cross-check `UpgradeItem#isCompatibleWith` (would previously only check that method on upgrades existing in the router but not the upgrade to be placed too) - I would call this more of a bug fix
- add a `AddModuleTargetEvent` that can be used to consider more blocks valid for a module - to be used with `ExecuteModuleEvent` - also comes with a bug fix, allowing the removal of invalid targets
- add a `RouterCompiledEvent` with a `Upgrades` and `Modules` sub-class: called when the router compiles its upgrades or modules, can be used to update state even after an upgrade is removed, à la energy buffers