### PR TITLE
Add search aliases for modules, augments and upgrades

### DIFF
--- a/src/main/java/me/desht/modularrouters/integration/jei/JEIModularRoutersPlugin.java
+++ b/src/main/java/me/desht/modularrouters/integration/jei/JEIModularRoutersPlugin.java
@@ -3,11 +3,17 @@ package me.desht.modularrouters.integration.jei;
 import me.desht.modularrouters.client.gui.ModularRouterScreen;
 import me.desht.modularrouters.client.gui.filter.BulkItemFilterScreen;
 import me.desht.modularrouters.client.gui.module.ModuleScreen;
+import me.desht.modularrouters.item.augment.AugmentItem;
+import me.desht.modularrouters.item.module.ModuleItem;
+import me.desht.modularrouters.item.upgrade.UpgradeItem;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.handlers.IGuiContainerHandler;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
+import mezz.jei.api.registration.IIngredientAliasRegistration;
 import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.List;
@@ -32,5 +38,18 @@ public class JEIModularRoutersPlugin implements IModPlugin {
                 return routerScreen.getExtraArea();
             }
         });
+    }
+
+    @Override
+    public void registerIngredientAliases(IIngredientAliasRegistration registration) {
+        for (var item : BuiltInRegistries.ITEM) {
+            if (item instanceof ModuleItem) {
+                registration.addAlias(VanillaTypes.ITEM_STACK, item.getDefaultInstance(), "Modular Router Module");
+            } else if (item instanceof UpgradeItem) {
+                registration.addAlias(VanillaTypes.ITEM_STACK, item.getDefaultInstance(), "Modular Router Upgrade");
+            } else if (item instanceof AugmentItem) {
+                registration.addAlias(VanillaTypes.ITEM_STACK, item.getDefaultInstance(), "Modular Router Module Augment");
+            }
+        }
     }
 }


### PR DESCRIPTION
The aliases make finding all available modules, augments and upgrades easy when addons are also in the game (as `@modularrouters module` wouldn't catch addons)