### PR TITLE
One more round of API improvements

### DIFF
--- a/src/main/java/me/desht/modularrouters/block/tile/ModularRouterBlockEntity.java
+++ b/src/main/java/me/desht/modularrouters/block/tile/ModularRouterBlockEntity.java
@@ -63,6 +63,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.neoforged.neoforge.capabilities.ItemCapability;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.energy.EnergyStorage;
@@ -987,6 +988,16 @@ public class ModularRouterBlockEntity extends BlockEntity implements ICamouflage
 
     public IFluidHandlerItem getFluidHandler() {
         return bufferHandler.getFluidHandler();
+    }
+
+    /**
+     * Returns the capability of the item in the router's buffer of the given type.
+     * @param cap the capability
+     * @param <T> the capability type
+     */
+    @Nullable
+    public <T> T getBufferCapability(ItemCapability<T, Void> cap) {
+        return bufferHandler.getCapability(cap);
     }
 
     public void sendBlockUpdateIfNeeded() {

--- a/src/main/java/me/desht/modularrouters/client/gui/module/ModuleScreen.java
+++ b/src/main/java/me/desht/modularrouters/client/gui/module/ModuleScreen.java
@@ -52,19 +52,19 @@ import java.util.Optional;
 import static me.desht.modularrouters.client.util.ClientUtil.xlate;
 
 public class ModuleScreen extends AbstractContainerScreen<ModuleMenu> implements ContainerListener, IMouseOverHelpProvider, ISendToServer {
-    static final ResourceLocation GUI_TEXTURE = MiscUtil.RL("textures/gui/module.png");
+    protected static final ResourceLocation GUI_TEXTURE = MiscUtil.RL("textures/gui/module.png");
 
     // locations of extra textures on the gui module texture sheet
-    static final XYPoint SMALL_TEXTFIELD_XY = new XYPoint(0, 198);
-    static final XYPoint LARGE_TEXTFIELD_XY = new XYPoint(0, 212);
-    static final XYPoint BUTTON_XY = new XYPoint(0, 226);
+    protected static final XYPoint SMALL_TEXTFIELD_XY = new XYPoint(0, 198);
+    protected static final XYPoint LARGE_TEXTFIELD_XY = new XYPoint(0, 212);
+    protected static final XYPoint BUTTON_XY = new XYPoint(0, 226);
 
     private static final int GUI_HEIGHT = 198;
     private static final int GUI_WIDTH = 192;
     private static final int BUTTON_WIDTH = 16;
     private static final int BUTTON_HEIGHT = 16;
 
-    final ItemStack moduleItemStack;
+    protected final ItemStack moduleItemStack;
     private final ModuleItem module;
     private final BlockPos routerPos;
     private final int moduleSlotIndex;
@@ -72,7 +72,7 @@ public class ModuleScreen extends AbstractContainerScreen<ModuleMenu> implements
     private final ModuleSettings settings;
     private int sendDelay;
     private final MouseOverHelp mouseOverHelp;
-    final AugmentItem.AugmentCounter augmentCounter;
+    protected final AugmentItem.AugmentCounter augmentCounter;
 
     private int regulatorAmount;
     private RelativeDirection facing;
@@ -81,7 +81,7 @@ public class ModuleScreen extends AbstractContainerScreen<ModuleMenu> implements
     private final EnumMap<RelativeDirection,DirectionButton> directionButtons = new EnumMap<>(RelativeDirection.class);
     private MouseOverHelp.Button mouseOverHelpButton;
     private TexturedToggleButton matchAllButton;
-    IntegerTextField regulatorTextField;
+    protected IntegerTextField regulatorTextField;
     private TerminationButton terminationButton;
     private ModuleToggleButton whiteListButton;
     private ModuleToggleButton matchDamageButton;
@@ -214,7 +214,7 @@ public class ModuleScreen extends AbstractContainerScreen<ModuleMenu> implements
      *
      * @param delay delay in ticks
      */
-    void sendModuleSettingsDelayed(int delay) {
+    protected void sendModuleSettingsDelayed(int delay) {
         sendDelay = delay;
     }
 
@@ -335,7 +335,7 @@ public class ModuleScreen extends AbstractContainerScreen<ModuleMenu> implements
         }
     }
 
-    Optional<ModularRouterBlockEntity> getItemRouter() {
+    protected Optional<ModularRouterBlockEntity> getItemRouter() {
         return routerPos != null ? Minecraft.getInstance().level.getBlockEntity(routerPos, ModBlockEntities.MODULAR_ROUTER.get()) : Optional.empty();
     }
 

--- a/src/main/java/me/desht/modularrouters/container/handler/BufferHandler.java
+++ b/src/main/java/me/desht/modularrouters/container/handler/BufferHandler.java
@@ -2,66 +2,83 @@ package me.desht.modularrouters.container.handler;
 
 import me.desht.modularrouters.block.tile.ModularRouterBlockEntity;
 import me.desht.modularrouters.core.ModBlocks;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.capabilities.ItemCapability;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
 import net.neoforged.neoforge.items.ItemStackHandler;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.IdentityHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BufferHandler extends ItemStackHandler {
+    // we mask null keys in the cap cache map with this object to avoid needing to check containsKey
+    private static final Object NULL = new Object();
+
     private final ModularRouterBlockEntity router;
 
-    private IEnergyStorage energyStorage;
-    private IFluidHandlerItem fluidHandler;
+    // default expected size of 2 is reasonable for most routers
+    private final IdentityHashMap<ItemCapability<?, Void>, Object> capabilityCache = new IdentityHashMap<>(4);
 
     public BufferHandler(ModularRouterBlockEntity router) {
         super(router.getBufferSlotCount());
         this.router = router;
-
-        setupFluidAndEnergyCaps();
     }
 
     @Override
     public void onContentsChanged(int slot) {
-        ItemStack stack = getStackInSlot(slot);
+        // small optimisation in case we don't have any caps requested already
+        if (!capabilityCache.isEmpty()) {
+            ItemStack stack = getStackInSlot(slot);
 
-        IFluidHandlerItem newFluidHandler = stack.getCapability(Capabilities.FluidHandler.ITEM);
-        IEnergyStorage newEnergyStorage = stack.getCapability(Capabilities.EnergyStorage.ITEM);
+            var modified = new AtomicBoolean();
 
-        if (newFluidHandler != fluidHandler || newEnergyStorage != energyStorage) {
-            fluidHandler = newFluidHandler;
-            energyStorage = newEnergyStorage;
+            // replace and invalidate if necessary the capabilities we previously returned
+            //noinspection rawtypes,unchecked
+            capabilityCache.replaceAll((cap, old) -> revalidate(stack, (ItemCapability) cap, old, modified));
 
-            router.invalidateCapabilities();
+            if (modified.get()) {
+                router.invalidateCapabilities();
 
-            // in case any pipes/cables need to connect/disconnect
-            router.nonNullLevel().updateNeighborsAt(router.getBlockPos(), ModBlocks.MODULAR_ROUTER.get());
+                // in case any pipes/cables need to connect/disconnect
+                router.nonNullLevel().updateNeighborsAt(router.getBlockPos(), ModBlocks.MODULAR_ROUTER.get());
+            }
         }
 
         router.setChanged();  // will also update comparator output
     }
 
-    @Override
-    public void deserializeNBT(HolderLookup.Provider provider, CompoundTag nbt) {
-        super.deserializeNBT(provider, nbt);
-
-        setupFluidAndEnergyCaps();
+    private <T> T revalidate(ItemStack stack, ItemCapability<T, Void> cap, T old, AtomicBoolean modified) {
+        var newVal = maskNull(stack.getCapability(cap));
+        if (newVal != old) {
+            modified.compareAndSet(false, true);
+        }
+        return newVal;
     }
 
     public IFluidHandlerItem getFluidHandler() {
-        return fluidHandler;
+        return getCapability(Capabilities.FluidHandler.ITEM);
     }
 
     public IEnergyStorage getEnergyStorage() {
-        return energyStorage;
+        return getCapability(Capabilities.EnergyStorage.ITEM);
     }
 
-    private void setupFluidAndEnergyCaps() {
-        ItemStack stack = getStackInSlot(0);
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <T> T getCapability(ItemCapability<T, Void> cap) {
+        var cached = capabilityCache.get(cap);
+        if (cached == null) {
+            cached = maskNull(getStackInSlot(0).getCapability(cap));
+            capabilityCache.put(cap, cached);
+        }
+        return cached == NULL ? null : (T)cached;
+    }
 
-        fluidHandler = stack.getCapability(Capabilities.FluidHandler.ITEM);
-        energyStorage = stack.getCapability(Capabilities.EnergyStorage.ITEM);
+    @SuppressWarnings("unchecked")
+    private static <T> T maskNull(T value) {
+        return value == null ? (T) NULL : value;
     }
 }

--- a/src/main/java/me/desht/modularrouters/integration/jei/BulkFilterScreenGhost.java
+++ b/src/main/java/me/desht/modularrouters/integration/jei/BulkFilterScreenGhost.java
@@ -16,7 +16,7 @@ public class BulkFilterScreenGhost implements IGhostIngredientHandler<BulkItemFi
         for (int i = 0; i < gui.getMenu().slots.size(); i++) {
             Slot s = gui.getMenu().getSlot(i);
             if (s instanceof FilterSlot) {
-                res.add(new GhostTarget<>(gui, s));
+                res.add(new GhostTarget<>(ingredient.getType(), gui, s));
             }
         }
         return res;

--- a/src/main/java/me/desht/modularrouters/integration/jei/GhostTarget.java
+++ b/src/main/java/me/desht/modularrouters/integration/jei/GhostTarget.java
@@ -2,15 +2,13 @@ package me.desht.modularrouters.integration.jei;
 
 import me.desht.modularrouters.network.messages.ModuleFilterMessage;
 import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.IIngredientType;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.fluids.FluidStack;
-import net.neoforged.neoforge.fluids.FluidUtil;
 import net.neoforged.neoforge.network.PacketDistributor;
 
-record GhostTarget<I>(AbstractContainerScreen<?> gui, Slot slot) implements IGhostIngredientHandler.Target<I> {
+record GhostTarget<I>(IIngredientType<I> type, AbstractContainerScreen<?> gui, Slot slot) implements IGhostIngredientHandler.Target<I> {
     @Override
     public Rect2i getArea() {
         return new Rect2i(slot.x + gui.getGuiLeft(), slot.y + gui.getGuiTop(), 16, 16);
@@ -18,12 +16,11 @@ record GhostTarget<I>(AbstractContainerScreen<?> gui, Slot slot) implements IGho
 
     @Override
     public void accept(I ingredient) {
-        if (ingredient instanceof ItemStack stack) {
-            PacketDistributor.sendToServer(new ModuleFilterMessage(slot.index, stack));
-        } else if (ingredient instanceof FluidStack fluidStack) {
-            ItemStack bucket = FluidUtil.getFilledBucket(fluidStack);
-            if (!bucket.isEmpty()) {
-                PacketDistributor.sendToServer(new ModuleFilterMessage(slot.index, bucket));
+        var creator = JEIModularRoutersPlugin.STACK_CREATORS.get(type);
+        if (creator != null) {
+            var stack = creator.apply(ingredient);
+            if (!stack.isEmpty()) {
+                PacketDistributor.sendToServer(new ModuleFilterMessage(slot.index, stack));
             }
         }
     }

--- a/src/main/java/me/desht/modularrouters/integration/jei/JEIModularRoutersPlugin.java
+++ b/src/main/java/me/desht/modularrouters/integration/jei/JEIModularRoutersPlugin.java
@@ -10,18 +10,36 @@ import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.handlers.IGuiContainerHandler;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.neoforge.NeoForgeTypes;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
 import mezz.jei.api.registration.IIngredientAliasRegistration;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.fluids.FluidUtil;
 
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 import static me.desht.modularrouters.util.MiscUtil.RL;
 
 @JeiPlugin
 public class JEIModularRoutersPlugin implements IModPlugin {
+    static final Map<IIngredientType<?>, Function<Object, ItemStack>> STACK_CREATORS = new IdentityHashMap<>();
+
+    public static synchronized <T> void registerGhostStackCreator(IIngredientType<T> type, Function<T, ItemStack> creator) {
+        STACK_CREATORS.put(type, object -> creator.apply((T) object));
+    }
+
+    public JEIModularRoutersPlugin() {
+        registerGhostStackCreator(VanillaTypes.ITEM_STACK, Function.identity());
+        registerGhostStackCreator(NeoForgeTypes.FLUID_STACK, FluidUtil::getFilledBucket);
+    }
+
     @Override
     public ResourceLocation getPluginUid() {
         return RL("default");

--- a/src/main/java/me/desht/modularrouters/integration/jei/ModuleScreenGhost.java
+++ b/src/main/java/me/desht/modularrouters/integration/jei/ModuleScreenGhost.java
@@ -16,7 +16,7 @@ public class ModuleScreenGhost implements IGhostIngredientHandler<ModuleScreen> 
         for (int i = 0; i < gui.getMenu().slots.size(); i++) {
             Slot s = gui.getMenu().getSlot(i);
             if (s instanceof FilterSlot) {
-                res.add(new GhostTarget<>(gui, s));
+                res.add(new GhostTarget<>(ingredient.getType(), gui, s));
             }
         }
         return res;

--- a/src/main/java/me/desht/modularrouters/item/MRBaseItem.java
+++ b/src/main/java/me/desht/modularrouters/item/MRBaseItem.java
@@ -41,7 +41,8 @@ public abstract class MRBaseItem extends Item {
     }
 
     protected void addUsageInformation(ItemStack itemstack, List<Component> list) {
-        list.add(xlate("modularrouters.itemText.usage.item." + BuiltInRegistries.ITEM.getKey(itemstack.getItem()).getPath(), getExtraUsageParams()));
+        var key = BuiltInRegistries.ITEM.getKey(itemstack.getItem());
+        list.add(xlate(key.getNamespace() + ".itemText.usage.item." + key.getPath(), getExtraUsageParams()));
     }
 
     protected abstract void addExtraInformation(ItemStack stack, List<Component> list);

--- a/src/main/java/me/desht/modularrouters/logic/compiled/CompiledFluidModule2.java
+++ b/src/main/java/me/desht/modularrouters/logic/compiled/CompiledFluidModule2.java
@@ -13,7 +13,7 @@ public class CompiledFluidModule2 extends CompiledFluidModule1 {
     }
 
     @Override
-    List<ModuleTarget> setupTargets(ModularRouterBlockEntity router, ItemStack stack) {
+    protected List<ModuleTarget> setupTargets(ModularRouterBlockEntity router, ItemStack stack) {
         ModuleTarget target = TargetedModule.getTarget(stack, !router.nonNullLevel().isClientSide);
         return target == null ? List.of() : List.of(target);
     }

--- a/src/main/java/me/desht/modularrouters/logic/compiled/CompiledModule.java
+++ b/src/main/java/me/desht/modularrouters/logic/compiled/CompiledModule.java
@@ -209,7 +209,7 @@ public abstract class CompiledModule {
      * @param stack the module itemstack
      * @return a list of router target objects (for most modules this is a singleton list)
      */
-    List<ModuleTarget> setupTargets(ModularRouterBlockEntity router, ItemStack stack) {
+    protected List<ModuleTarget> setupTargets(ModularRouterBlockEntity router, ItemStack stack) {
         if (router == null || (module.isDirectional() && getDirection() == RelativeDirection.NONE)) {
             return null;
         }


### PR DESCRIPTION
- Widen access of package-private members in `ModuleScreen` and `CompiledModule` which would otherwise make custom modules not very fun.
- Add an API to `ModuleTarget` that allows querying and caching multiple capabilities instead of only item, fluid and energy using a small IHM
- Add a cap cache to the buffer too instead of hardcoding fluids and energy
- Add `JEIModularRoutersPlugin#registerGhostStackCreator` to allow addons to create filter stacks from other ghost ingredients
- Make `MRBaseItem` use the correct lang namespace