### PR TITLE
Get gameplay enchantment levels for modules

### DIFF
--- a/src/main/java/me/desht/modularrouters/item/module/ModuleItem.java
+++ b/src/main/java/me/desht/modularrouters/item/module/ModuleItem.java
@@ -27,8 +27,10 @@ import me.desht.modularrouters.logic.settings.ModuleTermination;
 import me.desht.modularrouters.logic.settings.RedstoneBehaviour;
 import me.desht.modularrouters.logic.settings.RelativeDirection;
 import me.desht.modularrouters.util.MFLocator;
+
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
@@ -48,6 +50,8 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.Level;
+
+import net.neoforged.neoforge.common.CommonHooks;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -212,9 +216,9 @@ public abstract class ModuleItem extends MRBaseItem implements ModItems.ITintabl
             ItemStack pick = pickaxeUser.getPickaxe(stack);
             list.add(xlate("modularrouters.itemText.misc.breakerPick").withStyle(ChatFormatting.YELLOW)
                     .append(pick.getHoverName().plainCopy().withStyle(ChatFormatting.AQUA)));
-            pick.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).entrySet().forEach(holder -> {
+			pick.getAllEnchantments(CommonHooks.resolveLookup(Registries.ENCHANTMENT)).entrySet().forEach(mapEntry -> {
                 list.add(Component.literal("▶ ")
-                        .append(Enchantment.getFullname(holder.getKey(), holder.getIntValue()).copy().withStyle(ChatFormatting.AQUA))
+                        .append(Enchantment.getFullname(mapEntry.getKey(), mapEntry.getIntValue()).copy().withStyle(ChatFormatting.AQUA))
                         .withStyle(ChatFormatting.YELLOW));
             });
         }

--- a/src/main/java/me/desht/modularrouters/logic/filter/matchers/InspectionMatcher.java
+++ b/src/main/java/me/desht/modularrouters/logic/filter/matchers/InspectionMatcher.java
@@ -7,6 +7,8 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import me.desht.modularrouters.api.matching.IItemMatcher;
 import me.desht.modularrouters.api.matching.IModuleFlags;
 import me.desht.modularrouters.util.TranslatableEnum;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -16,6 +18,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
+import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 import net.neoforged.neoforge.fluids.FluidUtil;
@@ -170,7 +173,7 @@ public class InspectionMatcher implements IItemMatcher {
         }
 
         private static Optional<Integer> getHighestEnchantLevel(ItemStack stack) {
-            return stack.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).entrySet().stream()
+            return stack.getAllEnchantments(CommonHooks.resolveLookup(Registries.ENCHANTMENT)).entrySet().stream()
                     .map(Object2IntMap.Entry::getIntValue)
                     .max(Comparator.naturalOrder());
         }


### PR DESCRIPTION
This fixes modules which have enchantments with modified enchantment levels (Apotheosis affixes and gems for example) in them not showing their enchantment level correctly. Previously they only showed the "base" enchantmentlevel.